### PR TITLE
fix: center mint modal nft image

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -73,8 +73,11 @@ export default function Modal() {
 
             <div className={styles.content}>
               <p className="text-center text-lg">You have minted a new NFT!</p>
-
-              {tokenURI && <CollectibleCard tokenURI={tokenURI} />}
+              {tokenURI &&
+                <div className="mx-auto w-64">
+                  <CollectibleCard tokenURI={tokenURI} />
+                </div>
+              }
             </div>
 
             <div


### PR DESCRIPTION
Fix nft image on Modal.tsx, due to prior edits to CollectibleCard.tsx

From this:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/75003086/225418465-6ec8c3df-4a38-4218-bfd9-3bd2d8e306e5.png">

Back to this:
<img width="262" alt="image" src="https://user-images.githubusercontent.com/75003086/225418580-401a6c62-2d0f-4bff-a32b-2607f9b176ac.png">
